### PR TITLE
Gateway API: HTTPRoute шаблоны для citadel-monolith и static-proxy

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -23,6 +23,15 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
 
+    - name: Install Helm
+      uses: azure/setup-helm@v4
+      with:
+        version: v3.16.2
+
+    - name: Helm chart template tests (HTTPRoute)
+      run: |
+        ./scripts/helm-template-test.sh
+
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
 

--- a/charts/citadel-monolith/Chart.yaml
+++ b/charts/citadel-monolith/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: citadel
 description: A Helm chart for deploying monolithic applications in Kubernetes with enhanced security, monitoring, and configuration management
 type: application
-version: 0.2.0
+version: 0.2.1
 appVersion: "1.0.0"
 keywords:
   - kubernetes

--- a/charts/citadel-monolith/ci/gateway-api-values.yaml
+++ b/charts/citadel-monolith/ci/gateway-api-values.yaml
@@ -1,0 +1,27 @@
+# CI / local: minimal values to render HTTPRoute (Gateway API)
+common:
+  gatewayApi:
+    parentRefs:
+      - name: test-gateway
+        namespace: gateway-system
+
+applications:
+  - name: web
+    replicaCount: 1
+    image:
+      repository: nginx
+      tag: "1.29"
+    service:
+      type: ClusterIP
+      port: 80
+    gatewayApi:
+      enabled: true
+      hosts:
+        - host: app.example.com
+          paths:
+            - path: /
+              pathType: ImplementationSpecific
+        - host: api.example.com
+          paths:
+            - path: /v1
+              pathType: Prefix

--- a/charts/citadel-monolith/templates/_helpers.tpl
+++ b/charts/citadel-monolith/templates/_helpers.tpl
@@ -60,3 +60,23 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/* Kubernetes Gateway API: name for an HTTPRoute (one per application host) */}}
+{{- define "citadel-common.httprouteName" -}}
+{{- $root := .root }}{{- $app := .app }}{{- $i := .index -}}
+{{ include "citadel-common.fullname" $root }}-{{ $app.name }}-httproute-{{ $i }}
+{{- end }}
+
+{{/* Map Ingress pathType to gateway.networking.k8s.io path match type */}}
+{{- define "citadel-common.httproutePathMatchType" -}}
+{{- $t := . | default "ImplementationSpecific" -}}
+{{- if or (eq $t "Prefix") (eq $t "ImplementationSpecific") -}}
+PathPrefix
+{{- else if eq $t "Exact" -}}
+Exact
+{{- else if eq $t "RegularExpression" -}}
+RegularExpression
+{{- else -}}
+PathPrefix
+{{- end -}}
+{{- end }}

--- a/charts/citadel-monolith/templates/httproute.yaml
+++ b/charts/citadel-monolith/templates/httproute.yaml
@@ -1,0 +1,42 @@
+{{ $common := .Values.common }}
+{{- range $app := .Values.applications }}
+{{- if and $app.gatewayApi $app.gatewayApi.enabled }}
+{{- $parentRefs := $app.gatewayApi.parentRefs | default $common.gatewayApi.parentRefs }}
+{{- if and $parentRefs (gt (len $parentRefs) 0) }}
+{{- $hosts := $app.gatewayApi.hosts | default (list) }}
+{{- range $hi, $h := $hosts }}
+{{- if $h.paths }}
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "citadel-common.httprouteName" (dict "root" $ "app" $app "index" $hi) }}
+  labels:
+    {{- include "citadel-common.labels" $ | nindent 4 }}
+    {{- with $app.gatewayApi.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with $app.gatewayApi.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+  {{- toYaml $parentRefs | nindent 2 }}
+  hostnames:
+  - {{ $h.host | quote }}
+  rules:
+  {{- range $h.paths }}
+  - matches:
+    - path:
+        type: {{ include "citadel-common.httproutePathMatchType" .pathType }}
+        value: {{ .path | quote }}
+    backendRefs:
+    - name: {{ include "citadel-common.fullname" $ }}-{{ $app.name }}
+      port: {{ $app.service.port }}
+  {{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/citadel-monolith/values.yaml
+++ b/charts/citadel-monolith/values.yaml
@@ -53,6 +53,14 @@ common:
         secretName: client-infisical-secrets
   ingress:
     className: nginx
+  # Kubernetes Gateway API defaults (optional; per-app can override parentRefs).
+  # Cluster-scoped Gateway and GatewayClass are deployed elsewhere; this chart only renders HTTPRoute.
+  gatewayApi:
+    parentRefs: []
+    #  - name: my-gateway
+    #    namespace: istio-system
+    #    group: gateway.networking.k8s.io
+    #    kind: Gateway
 
 cronjobs: []
   # - name: backup
@@ -132,6 +140,21 @@ applications: []
   #     #  - secretName: chart-example-tls
   #     #    hosts:
   #     #      - chart-example.local
+
+  #   # Kubernetes Gateway API: HTTPRoute to an existing Gateway (see templates/httproute.yaml)
+  #   gatewayApi:
+  #     enabled: true
+  #     parentRefs:
+  #       - name: my-gateway
+  #         namespace: istio-system
+  #     # One HTTPRoute per list entry; map pathType as in ingress (Prefix/Exact/... → PathPrefix, etc.)
+  #     hosts:
+  #       - host: app.example.com
+  #         paths:
+  #           - path: /
+  #             pathType: ImplementationSpecific
+  #     labels: {}
+  #     annotations: {}
 
   #   resources:
   #     limits:

--- a/charts/static-proxy/Chart.yaml
+++ b/charts/static-proxy/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: static-proxy
 description: A Helm chart for deploying an Nginx proxy to S3 buckets
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "1.16.0"

--- a/charts/static-proxy/ci/gateway-api-values.yaml
+++ b/charts/static-proxy/ci/gateway-api-values.yaml
@@ -1,0 +1,9 @@
+# CI / local: render HTTPRoute for static-proxy
+gatewayApi:
+  enabled: true
+  parentRefs:
+    - name: test-gateway
+      namespace: gateway-system
+
+ingress:
+  host: static.example.com

--- a/charts/static-proxy/templates/_helpers.tpl
+++ b/charts/static-proxy/templates/_helpers.tpl
@@ -49,3 +49,23 @@ Selector labels
 app.kubernetes.io/name: {{ include "static-proxy.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
+
+{{/* HTTPRoute name for static-proxy (single host, single resource) */}}
+{{- define "static-proxy.httprouteName" -}}
+{{- $root := .root -}}
+{{ include "static-proxy.fullname" $root }}-httproute
+{{- end }}
+
+{{/* Map pathType to gateway.networking.k8s.io path match type */}}
+{{- define "static-proxy.httproutePathMatchType" -}}
+{{- $t := . | default "ImplementationSpecific" -}}
+{{- if or (eq $t "Prefix") (eq $t "ImplementationSpecific") -}}
+PathPrefix
+{{- else if eq $t "Exact" -}}
+Exact
+{{- else if eq $t "RegularExpression" -}}
+RegularExpression
+{{- else -}}
+PathPrefix
+{{- end -}}
+{{- end }}

--- a/charts/static-proxy/templates/httproute.yaml
+++ b/charts/static-proxy/templates/httproute.yaml
@@ -1,0 +1,35 @@
+{{- if and .Values.gatewayApi .Values.gatewayApi.enabled }}
+{{- $parentRefs := .Values.gatewayApi.parentRefs }}
+{{- if and $parentRefs (gt (len $parentRefs) 0) }}
+{{- $host := .Values.gatewayApi.host | default .Values.ingress.host }}
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "static-proxy.httprouteName" (dict "root" .) }}
+  labels:
+    {{- include "static-proxy.labels" . | nindent 4 }}
+    {{- with .Values.gatewayApi.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.gatewayApi.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+  {{- toYaml $parentRefs | nindent 2 }}
+  hostnames:
+  - {{ $host | quote }}
+  rules:
+  {{- range .Values.config.targets }}
+  - matches:
+    - path:
+        type: {{ include "static-proxy.httproutePathMatchType" .pathType }}
+        value: {{ .target | quote }}
+    backendRefs:
+    - name: {{ $.Values.service.name | default (include "static-proxy.fullname" $) }}
+      port: {{ $.Values.service.port }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/static-proxy/values.yaml
+++ b/charts/static-proxy/values.yaml
@@ -58,6 +58,17 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
+# Kubernetes Gateway API: HTTPRoute to an existing Gateway (Gateway/GatewayClass deployed separately).
+gatewayApi:
+  enabled: false
+  # If empty, the route uses ingress.host
+  # host: static-proxy.example.com
+  parentRefs: []
+  #  - name: my-gateway
+  #    namespace: istio-system
+  labels: {}
+  annotations: {}
+
 resources: {}
   # limits:
   #   cpu: 100m

--- a/scripts/helm-template-test.sh
+++ b/scripts/helm-template-test.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+echo "== citadel-monolith: gateway API values =="
+helm template test-citadel charts/citadel-monolith \
+  -f charts/citadel-monolith/ci/gateway-api-values.yaml \
+  --show-only templates/httproute.yaml
+
+echo "== static-proxy: gateway API values =="
+helm template test-static charts/static-proxy \
+  -f charts/static-proxy/ci/gateway-api-values.yaml \
+  --show-only templates/httproute.yaml
+
+echo "OK: Gateway API templates render successfully."


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Что сделано

Добавлена опциональная поддержка **Kubernetes Gateway API** на уровне приложения: в чартах рендерятся только **HTTPRoute** (ресурсы), которые ссылаются на уже существующий **Gateway** через `parentRefs`. `Gateway` и `GatewayClass` по-прежнему разворачиваются отдельно.

### citadel-monolith
- Новый шаблон `templates/httproute.yaml`.
- В `values`: `common.gatewayApi.parentRefs` (дефолт для приложений) и у каждого приложения — `gatewayApi.enabled`, `parentRefs` (опционально), `hosts` / `paths` в том же духе, что и у ingress. На каждый элемент `hosts` создаётся отдельный `HTTPRoute` (как у ingress — отдельные правила по хосту).
- `pathType` из ingress маппится в тип матча Gateway API: `Prefix` / `ImplementationSpecific` → `PathPrefix`, `Exact` → `Exact`, `RegularExpression` → `RegularExpression`.

### static-proxy
- Аналогично: `gatewayApi` в `values`, один `HTTPRoute` с правилами по `config.targets` (как пути в ingress). Хост: `gatewayApi.host` или, если не задан, `ingress.host`.

### Тесты и CI
- Скрипт `scripts/helm-template-test.sh` и sample values в `charts/*/ci/gateway-api-values.yaml`.
- В workflow `docker-build` добавлены шаги установки Helm и прогон этого скрипта.

### Версии чартов
- citadel-monolith: 0.2.0 → **0.2.1**
- static-proxy: 0.1.0 → **0.1.1**
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-89688fb3-5ab4-43a8-8433-ec47752846ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-89688fb3-5ab4-43a8-8433-ec47752846ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

