### PR TITLE
feat(helm): HPA с k8s/Prometheus-метриками и настройкой политики

### DIFF
--- a/charts/citadel-monolith/ci/hpa-values.yaml
+++ b/charts/citadel-monolith/ci/hpa-values.yaml
@@ -1,0 +1,41 @@
+# CI: HPA с resource + Pods (симуляция custom metric из prometheus-adapter) + behavior
+applications:
+  - name: web
+    replicaCount: 1
+    image:
+      repository: nginx
+      tag: "1.29"
+    service:
+      type: ClusterIP
+      port: 80
+    autoscaling:
+      enabled: true
+      minReplicas: 1
+      maxReplicas: 5
+      targetCPUUtilizationPercentage: 70
+      podsMetrics:
+        - type: Pods
+          pods:
+            metric:
+              name: http_requests_per_second
+            target:
+              type: AverageValue
+              averageValue: "10"
+      behavior:
+        scaleDown:
+          stabilizationWindowSeconds: 60
+          selectPolicy: Min
+          policies:
+            - type: Percent
+              value: 20
+              periodSeconds: 60
+        scaleUp:
+          stabilizationWindowSeconds: 0
+          selectPolicy: Max
+          policies:
+            - type: Percent
+              value: 100
+              periodSeconds: 15
+            - type: Pods
+              value: 2
+              periodSeconds: 15

--- a/charts/citadel-monolith/templates/hpa.yaml
+++ b/charts/citadel-monolith/templates/hpa.yaml
@@ -4,9 +4,14 @@
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: {{ include "citadel-common.fullname" $ }}
+  name: {{ include "citadel-common.fullname" $ }}-{{ .name }}
   labels:
     {{- include "citadel-common.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: {{ .name }}
+  {{- with .autoscaling.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
@@ -15,21 +20,43 @@ spec:
   minReplicas: {{ .autoscaling.minReplicas }}
   maxReplicas: {{ .autoscaling.maxReplicas }}
   metrics:
-    {{- if .autoscaling.targetCPUUtilizationPercentage }}
+    {{- with .autoscaling.targetCPUUtilizationPercentage }}
     - type: Resource
       resource:
         name: cpu
         target:
           type: Utilization
-          averageUtilization: {{ .autoscaling.targetCPUUtilizationPercentage }}
+          averageUtilization: {{ . }}
     {{- end }}
-    {{- if .autoscaling.targetMemoryUtilizationPercentage }}
+    {{- with .autoscaling.targetMemoryUtilizationPercentage }}
     - type: Resource
       resource:
         name: memory
         target:
           type: Utilization
-          averageUtilization: {{ .autoscaling.targetMemoryUtilizationPercentage }}
+          averageUtilization: {{ . }}
     {{- end }}
+    {{- with .autoscaling.resourceMetrics }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .autoscaling.podsMetrics }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .autoscaling.objectMetrics }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .autoscaling.externalMetrics }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .autoscaling.containerResourceMetrics }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .autoscaling.additionalMetrics }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .autoscaling.behavior }}
+  behavior:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/citadel-monolith/values.yaml
+++ b/charts/citadel-monolith/values.yaml
@@ -164,6 +164,41 @@ applications: []
   #       cpu: 100m
   #       memory: 128Mi
 
+  #   # HPA: CPU/memory (сокращения) + metrics/behavior (autoscaling/v2) для Pod/External/Object/ContainerResource
+  #   # Метрики из Prometheus: установите prometheus-adapter (или kube-prometheus-stack) и укажите custom/external metric:
+  #   #   podsMetrics: [{ type: Pods, pods: { metric: { name: http_requests_per_second }, target: { type: AverageValue, averageValue: "10" } } }]
+  #   autoscaling:
+  #     enabled: false
+  #     minReplicas: 1
+  #     maxReplicas: 10
+  #     # 0 — не добавлять resource-метрику CPU/memory в HPA
+  #     targetCPUUtilizationPercentage: 80
+  #     # targetMemoryUtilizationPercentage: 80
+  #     # annotations: {}
+  #     # resourceMetrics: []   # type: Resource (доп. к targetCPU...), например averageValue по CPU
+  #     # podsMetrics: []       # агрегаты по подам; часто сюда кладут метрику из Prometheus Adapter
+  #     # objectMetrics: []
+  #     # externalMetrics: []
+  #     # containerResourceMetrics: []  # type: ContainerResource
+  #     # additionalMetrics: []         # произвольные блоки v2 (как в манифесте)
+  #     # behavior:
+  #     #   scaleDown:
+  #     #     stabilizationWindowSeconds: 300
+  #     #     policies:
+  #     #       - type: Percent
+  #     #         value: 50
+  #     #         periodSeconds: 60
+  #     #   scaleUp:
+  #     #     stabilizationWindowSeconds: 0
+  #     #     policies:
+  #     #       - type: Percent
+  #     #         value: 100
+  #     #         periodSeconds: 15
+  #     #       - type: Pods
+  #     #         value: 4
+  #     #         periodSeconds: 15
+  #     #     selectPolicy: Max
+
   #   # This is to setup the liveness, readiness and startup probes more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
   #   startupProbe:
   #     httpGet:

--- a/charts/static-proxy/ci/hpa-values.yaml
+++ b/charts/static-proxy/ci/hpa-values.yaml
@@ -1,0 +1,28 @@
+# CI: HPA с политикой scaleUp/scaleDown
+replicaCount: 1
+autoscaling:
+  enabled: true
+  minReplicas: 1
+  maxReplicas: 10
+  # 0 отключает CPU-метрику (with в шаблоне не рендерит 0)
+  targetCPUUtilizationPercentage: 0
+  targetMemoryUtilizationPercentage: 80
+  behavior:
+    scaleDown:
+      stabilizationWindowSeconds: 120
+    scaleUp:
+      policies:
+        - type: Percent
+          value: 100
+          periodSeconds: 30
+      selectPolicy: Max
+image:
+  repository: nginx
+  tag: "1.29"
+service:
+  type: ClusterIP
+  port: 80
+config:
+  targets: []
+ingress:
+  host: hpa-test.local

--- a/charts/static-proxy/templates/hpa.yaml
+++ b/charts/static-proxy/templates/hpa.yaml
@@ -5,6 +5,10 @@ metadata:
   name: {{ include "static-proxy.fullname" . }}
   labels:
     {{- include "static-proxy.labels" . | nindent 4 }}
+  {{- with .Values.autoscaling.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
@@ -13,20 +17,42 @@ spec:
   minReplicas: {{ .Values.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.autoscaling.maxReplicas }}
   metrics:
-    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- with .Values.autoscaling.targetCPUUtilizationPercentage }}
     - type: Resource
       resource:
         name: cpu
         target:
           type: Utilization
-          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+          averageUtilization: {{ . }}
     {{- end }}
-    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- with .Values.autoscaling.targetMemoryUtilizationPercentage }}
     - type: Resource
       resource:
         name: memory
         target:
           type: Utilization
-          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+          averageUtilization: {{ . }}
     {{- end }}
+    {{- with .Values.autoscaling.resourceMetrics }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.autoscaling.podsMetrics }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.autoscaling.objectMetrics }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.autoscaling.externalMetrics }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.autoscaling.containerResourceMetrics }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.autoscaling.additionalMetrics }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.autoscaling.behavior }}
+  behavior:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/charts/static-proxy/values.yaml
+++ b/charts/static-proxy/values.yaml
@@ -82,8 +82,28 @@ autoscaling:
   enabled: false
   minReplicas: 1
   maxReplicas: 100
+  # Укажите 0, чтобы не добавлять эту resource-метрику в HPA
   targetCPUUtilizationPercentage: 80
   # targetMemoryUtilizationPercentage: 80
+  # Доп. метрики (Resource/Pod/Object/External/ContainerResource) — см. autoscaling/v2. Prometheus:
+  # установите адаптер, затем укажите, например, podsMetrics / externalMetrics.
+  # annotations: {}
+  # resourceMetrics: []
+  # podsMetrics: []
+  # objectMetrics: []
+  # externalMetrics: []
+  # containerResourceMetrics: []
+  # additionalMetrics: []
+  # behavior:
+  #   scaleDown:
+  #     stabilizationWindowSeconds: 300
+  #   scaleUp:
+  #     stabilizationWindowSeconds: 0
+  #     selectPolicy: Max
+  #     policies:
+  #       - type: Percent
+  #         value: 100
+  #         periodSeconds: 15
 
 
 nodeSelector: {}

--- a/scripts/helm-template-test.sh
+++ b/scripts/helm-template-test.sh
@@ -21,4 +21,17 @@ helm template test-static charts/static-proxy \
   -f charts/static-proxy/ci/gateway-api-values.yaml \
   --show-only templates/httproute.yaml
 
-echo "OK: Gateway API templates render successfully."
+echo "== citadel-monolith: HPA (metrics + behavior) =="
+helm template test-citadel-hpa charts/citadel-monolith \
+  -f charts/citadel-monolith/ci/hpa-values.yaml \
+  --namespace app-test \
+  --show-only templates/hpa.yaml \
+  --show-only templates/deployment.yaml
+
+echo "== static-proxy: HPA (behavior) =="
+helm template test-static-hpa charts/static-proxy \
+  -f charts/static-proxy/ci/hpa-values.yaml \
+  --show-only templates/hpa.yaml \
+  --show-only templates/deployment.yaml
+
+echo "OK: Gateway API and HPA templates render successfully."


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Что сделано

- **citadel-monolith** и **static-proxy**: HPA (autoscaling/v2) расширен:
  - стандартные `targetCPUUtilizationPercentage` / `targetMemoryUtilizationPercentage` (значение **0** = не добавлять соответствующую resource-метрику, чтобы можно было оставить только custom/Prometheus-метрики);
  - произвольные фрагменты списка `metrics`: `resourceMetrics`, `podsMetrics`, `objectMetrics`, `externalMetrics`, `containerResourceMetrics`, `additionalMetrics` (как в манифесте Kubernetes, без преобразования);
  - **`behavior`** (policies, stabilizationWindow, selectPolicy для scaleUp/scaleDown);
  - **annotations** на HPA;
  - **исправлено** имя HPA в monolith-чарте: раньше для нескольких приложений получался один и тот же `name`, теперь `{{ fullname }}-{{ .name }}` + метка `app.kubernetes.io/component` на HPA.
- **CI**: `ci/hpa-values.yaml` для обоих чартов, `scripts/helm-template-test.sh` рендерит HPA+Deployment.

## Prometheus

Метрики в формате **Pods** / **Object** / **External** (часто через [prometheus-adapter](https://github.com/kubernetes-sigs/prometheus-adapter) или KEDA) настраиваются в values через `podsMetrics` / `objectMetrics` / `externalMetrics` (пример `pods` с метрикой `http_requests_per_second` — в `charts/citadel-monolith/ci/hpa-values.yaml`).

## Тесты

Локально: `helm template` (скрипт в репозитории).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-83767891-93f1-4038-ba31-ffed98cb3b24"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-83767891-93f1-4038-ba31-ffed98cb3b24"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

