### PR TITLE
citadel-monolith: Grafana SRE dashboard (ConfigMap + JSON)

### DIFF
--- a/charts/citadel-monolith/Chart.yaml
+++ b/charts/citadel-monolith/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: citadel
 description: A Helm chart for deploying monolithic applications in Kubernetes with enhanced security, monitoring, and configuration management
 type: application
-version: 0.2.4
+version: 0.2.5
 appVersion: "1.0.0"
 keywords:
   - kubernetes

--- a/charts/citadel-monolith/ci/sre-dashboard-values.yaml
+++ b/charts/citadel-monolith/ci/sre-dashboard-values.yaml
@@ -1,0 +1,7 @@
+# CI: Grafana SRE dashboard ConfigMap (kube-prometheus-stack sidecar)
+common:
+  grafana:
+    dashboard:
+      enabled: true
+      labels:
+        grafana_dashboard: "1"

--- a/charts/citadel-monolith/files/grafana-dashboards/citadel-sre.json
+++ b/charts/citadel-monolith/files/grafana-dashboards/citadel-sre.json
@@ -1,0 +1,1902 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 100,
+      "panels": [],
+      "title": "Ingress / API Gateway (nginx ingress controller)",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 1
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (host) (rate(nginx_ingress_controller_requests{namespace=~\"$ingress_controller_namespace\"}[5m]))",
+          "legendFormat": "{{host}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "RPS по host (ingress)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 1
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (ingress) (rate(nginx_ingress_controller_requests{namespace=~\"$ingress_controller_namespace\"}[5m]))",
+          "legendFormat": "{{ingress}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (service) (rate(nginx_ingress_controller_requests{namespace=~\"$ingress_controller_namespace\"}[5m]))",
+          "legendFormat": "{{service}}",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "RPS по ingress и по service (upstream)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 9
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum(rate(nginx_ingress_controller_request_duration_seconds_bucket{namespace=~\"$ingress_controller_namespace\"}[5m])) by (le))",
+          "legendFormat": "p50",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum(rate(nginx_ingress_controller_request_duration_seconds_bucket{namespace=~\"$ingress_controller_namespace\"}[5m])) by (le))",
+          "legendFormat": "p95",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum(rate(nginx_ingress_controller_request_duration_seconds_bucket{namespace=~\"$ingress_controller_namespace\"}[5m])) by (le))",
+          "legendFormat": "p99",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Latency ingress — p50 / p95 / p99",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 9
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(nginx_ingress_controller_requests{namespace=~\"$ingress_controller_namespace\",status=~\"4..\"}[5m]))",
+          "legendFormat": "4xx",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(nginx_ingress_controller_requests{namespace=~\"$ingress_controller_namespace\",status=~\"5..\"}[5m]))",
+          "legendFormat": "5xx",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "HTTP 4xx / 5xx (ingress)",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 17
+      },
+      "id": 101,
+      "panels": [],
+      "title": "Приложение (namespace релиза)",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 18
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (job) (rate(http_requests_total{namespace=\"$namespace\"}[5m]))",
+          "legendFormat": "http_requests_total",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (job) (rate(http_server_requests_total{namespace=\"$namespace\"}[5m]))",
+          "legendFormat": "http_server_requests_total",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "RPS по job (http_requests_total / http_server)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 18
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket{namespace=\"$namespace\"}[5m])) by (le, job))",
+          "legendFormat": "http_request_duration_seconds",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum(rate(http_server_duration_seconds_bucket{namespace=\"$namespace\"}[5m])) by (le, job))",
+          "legendFormat": "http_server_duration_seconds",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Latency приложения p95 (histogram)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 26
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(http_requests_total{namespace=\"$namespace\",status=~\"5..\"}[5m]))",
+          "legendFormat": "5xx",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(http_requests_total{namespace=\"$namespace\",status=~\"4..\"}[5m]))",
+          "legendFormat": "4xx",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "4xx / 5xx приложение (http_requests_total)",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 34
+      },
+      "id": 102,
+      "panels": [],
+      "title": "Kubernetes: поды, ресурсы, джобы",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 35
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (pod) (kube_pod_container_status_restarts_total{namespace=\"$namespace\"})",
+          "legendFormat": "{{pod}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Рестарты контейнеров по pod",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s/s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 35
+      },
+      "id": 9,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (pod) (rate(container_cpu_cfs_throttled_seconds_total{namespace=\"$namespace\", container!=\"\"}[5m]))",
+          "legendFormat": "{{pod}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "CPU throttling (container_cpu_cfs_throttled)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 43
+      },
+      "id": 10,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (pod) (rate(container_cpu_usage_seconds_total{namespace=\"$namespace\", container!=\"POD\", container!=\"\"}[5m]))",
+          "legendFormat": "usage",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (pod) (kube_pod_container_resource_requests{namespace=\"$namespace\", resource=\"cpu\", container!=\"POD\", container!=\"\"})",
+          "legendFormat": "requests",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "CPU: usage vs requests (cores)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 43
+      },
+      "id": 11,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (pod) (container_memory_working_set_bytes{namespace=\"$namespace\", container!=\"POD\", container!=\"\"})",
+          "legendFormat": "workingset",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (pod) (kube_pod_container_resource_limits{namespace=\"$namespace\", resource=\"memory\", container!=\"POD\", container!=\"\"})",
+          "legendFormat": "limit",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Memory: working set vs limit",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 51
+      },
+      "id": 12,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "clamp_max(sum(kube_pod_container_resource_requests{namespace=\"$namespace\",resource=\"cpu\"}) / sum(kube_pod_container_resource_limits{namespace=\"$namespace\",resource=\"cpu\"}), 1)",
+          "legendFormat": "cpu",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "clamp_max(sum(kube_pod_container_resource_requests{namespace=\"$namespace\",resource=\"memory\"}) / sum(kube_pod_container_resource_limits{namespace=\"$namespace\",resource=\"memory\"}), 1)",
+          "legendFormat": "memory",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Доля requests от limits (CPU и memory, сумма по namespace)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 51
+      },
+      "id": 13,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(kube_pod_status_phase{namespace=\"$namespace\",phase=\"Pending\"})",
+          "legendFormat": "Pending",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(kube_pod_status_phase{namespace=\"$namespace\",phase=\"Running\"})",
+          "legendFormat": "Running",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(kube_pod_status_phase{namespace=\"$namespace\",phase=\"Failed\"})",
+          "legendFormat": "Failed",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(kube_pod_status_phase{namespace=\"$namespace\",phase=\"Succeeded\"})",
+          "legendFormat": "Succeeded",
+          "range": true,
+          "refId": "D"
+        }
+      ],
+      "title": "Фазы подов (Pod phase)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 58
+      },
+      "id": 14,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(kube_pod_status_condition{namespace=\"$namespace\",condition=\"Ready\",status=\"false\"})",
+          "legendFormat": "NotReady count",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Ready condition (не готовы)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 58
+      },
+      "id": 15,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(kube_job_status_failed{namespace=\"$namespace\"})",
+          "legendFormat": "failed",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(kube_job_status_active{namespace=\"$namespace\"})",
+          "legendFormat": "active",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(kube_job_status_succeeded{namespace=\"$namespace\"})",
+          "legendFormat": "succeeded",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Jobs: failed / active / succeeded",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 65
+      },
+      "id": 16,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "kube_cronjob_info{namespace=\"$namespace\"}",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "__auto",
+          "refId": "A"
+        }
+      ],
+      "title": "CronJobs (kube_cronjob_info)",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "Value": true
+            },
+            "indexByName": {},
+            "renameByName": {
+              "cronjob": "CronJob"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 24,
+        "x": 0,
+        "y": 73
+      },
+      "id": 999,
+      "options": {
+        "content": "**SRE-дашборд Citadel (Helm).** Ingress: метрики `nginx_ingress_controller_*` (ingress-nginx). При другом ingress замените запросы. Приложение: типичные метрики Prometheus/OpenTelemetry. Кластер: kube-state-metrics + cAdvisor. SLI по доступности: правило `up` для ServiceMonitor (PrometheusRule в чарте).",
+        "mode": "markdown"
+      },
+      "pluginVersion": "10.0.0",
+      "title": "Примечания",
+      "type": "text"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": [
+    "citadel",
+    "kubernetes",
+    "sre"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "Prometheus",
+          "value": "Prometheus"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Datasource",
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": false,
+          "text": "",
+          "value": ""
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(kube_pod_info, namespace)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Namespace",
+        "name": "namespace",
+        "query": {
+          "query": "label_values(kube_pod_info, namespace)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": true,
+          "text": "ingress-nginx",
+          "value": "ingress-nginx"
+        },
+        "hide": 0,
+        "label": "Ingress controller NS",
+        "name": "ingress_controller_namespace",
+        "query": "ingress-nginx",
+        "skipUrlSync": false,
+        "type": "textbox"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timezone": "browser",
+  "title": "Citadel — SRE dashboard",
+  "uid": "citadel-sre-release",
+  "version": 1
+}

--- a/charts/citadel-monolith/files/grafana-dashboards/citadel-sre.json
+++ b/charts/citadel-monolith/files/grafana-dashboards/citadel-sre.json
@@ -18,8 +18,8 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
+  "id": 55,
   "links": [],
-  "liveNow": false,
   "panels": [
     {
       "collapsed": false,
@@ -51,6 +51,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 10,
             "gradientMode": "none",
@@ -81,8 +82,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -113,11 +113,12 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "multi",
           "sort": "desc"
         }
       },
-      "pluginVersion": "10.0.0",
+      "pluginVersion": "11.6.1",
       "targets": [
         {
           "datasource": {
@@ -125,7 +126,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum by (host) (rate(nginx_ingress_controller_requests{namespace=~\"$ingress_controller_namespace\"}[5m]))",
+          "expr": "sum by (host) (rate(nginx_ingress_controller_requests{host=\"$ingress_controller_namespace\"}[5m]))",
           "legendFormat": "{{host}}",
           "range": true,
           "refId": "A"
@@ -151,6 +152,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 10,
             "gradientMode": "none",
@@ -181,8 +183,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -213,11 +214,12 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "multi",
           "sort": "desc"
         }
       },
-      "pluginVersion": "10.0.0",
+      "pluginVersion": "11.6.1",
       "targets": [
         {
           "datasource": {
@@ -225,19 +227,8 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum by (ingress) (rate(nginx_ingress_controller_requests{namespace=~\"$ingress_controller_namespace\"}[5m]))",
-          "legendFormat": "{{ingress}}",
-          "range": true,
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "editorMode": "code",
-          "expr": "sum by (service) (rate(nginx_ingress_controller_requests{namespace=~\"$ingress_controller_namespace\"}[5m]))",
-          "legendFormat": "{{service}}",
+          "expr": "sum by (exported_service, path) (rate(nginx_ingress_controller_requests{host=~\"$ingress_controller_namespace\"}[5m]))",
+          "legendFormat": "{{exported_service}} - {{path}}",
           "range": true,
           "refId": "B"
         }
@@ -262,6 +253,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 10,
             "gradientMode": "none",
@@ -292,8 +284,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -324,11 +315,12 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "multi",
           "sort": "desc"
         }
       },
-      "pluginVersion": "10.0.0",
+      "pluginVersion": "11.6.1",
       "targets": [
         {
           "datasource": {
@@ -336,8 +328,8 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.50, sum(rate(nginx_ingress_controller_request_duration_seconds_bucket{namespace=~\"$ingress_controller_namespace\"}[5m])) by (le))",
-          "legendFormat": "p50",
+          "expr": "histogram_quantile(0.50, sum(rate(nginx_ingress_controller_request_duration_seconds_bucket{exported_namespace=\"$namespace\"}[5m])) by (le, exported_service, path))",
+          "legendFormat": "{{exported_service}} - {{path}} - p50",
           "range": true,
           "refId": "A"
         },
@@ -347,8 +339,8 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.95, sum(rate(nginx_ingress_controller_request_duration_seconds_bucket{namespace=~\"$ingress_controller_namespace\"}[5m])) by (le))",
-          "legendFormat": "p95",
+          "expr": "histogram_quantile(0.95, sum(rate(nginx_ingress_controller_request_duration_seconds_bucket{exported_namespace=\"$namespace\"}[5m])) by (le, exported_service, path))",
+          "legendFormat": "{{exported_service}} - {{path}} - p95",
           "range": true,
           "refId": "B"
         },
@@ -358,8 +350,8 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.99, sum(rate(nginx_ingress_controller_request_duration_seconds_bucket{namespace=~\"$ingress_controller_namespace\"}[5m])) by (le))",
-          "legendFormat": "p99",
+          "expr": "histogram_quantile(0.99, sum(rate(nginx_ingress_controller_request_duration_seconds_bucket{namespace=~\"$namespace\"}[5m])) by (le, exported_service, path))",
+          "legendFormat": "{{exported_service}} - {{path}} - p99",
           "range": true,
           "refId": "C"
         }
@@ -384,6 +376,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 10,
             "gradientMode": "none",
@@ -414,8 +407,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -446,11 +438,12 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "multi",
           "sort": "desc"
         }
       },
-      "pluginVersion": "10.0.0",
+      "pluginVersion": "11.6.1",
       "targets": [
         {
           "datasource": {
@@ -458,7 +451,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(nginx_ingress_controller_requests{namespace=~\"$ingress_controller_namespace\",status=~\"4..\"}[5m]))",
+          "expr": "sum(rate(nginx_ingress_controller_requests{exported_namespace=\"$namespace\",status=~\"4..\"}[5m])) by (exported_service)",
           "legendFormat": "4xx",
           "range": true,
           "refId": "A"
@@ -469,7 +462,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(nginx_ingress_controller_requests{namespace=~\"$ingress_controller_namespace\",status=~\"5..\"}[5m]))",
+          "expr": "sum(rate(nginx_ingress_controller_requests{exported_namespace=\"$namespace\",status=~\"5..\"}[5m])) by (exported_service)",
           "legendFormat": "5xx",
           "range": true,
           "refId": "B"
@@ -485,352 +478,6 @@
         "w": 24,
         "x": 0,
         "y": 17
-      },
-      "id": 101,
-      "panels": [],
-      "title": "Приложение (namespace релиза)",
-      "type": "row"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 10,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "smooth",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "reqps"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 18
-      },
-      "id": 5,
-      "options": {
-        "legend": {
-          "calcs": [
-            "mean",
-            "max",
-            "lastNotNull"
-          ],
-          "displayMode": "table",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
-        }
-      },
-      "pluginVersion": "10.0.0",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "editorMode": "code",
-          "expr": "sum by (job) (rate(http_requests_total{namespace=\"$namespace\"}[5m]))",
-          "legendFormat": "http_requests_total",
-          "range": true,
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "editorMode": "code",
-          "expr": "sum by (job) (rate(http_server_requests_total{namespace=\"$namespace\"}[5m]))",
-          "legendFormat": "http_server_requests_total",
-          "range": true,
-          "refId": "B"
-        }
-      ],
-      "title": "RPS по job (http_requests_total / http_server)",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 10,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "smooth",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "s"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 18
-      },
-      "id": 6,
-      "options": {
-        "legend": {
-          "calcs": [
-            "mean",
-            "max",
-            "lastNotNull"
-          ],
-          "displayMode": "table",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
-        }
-      },
-      "pluginVersion": "10.0.0",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "editorMode": "code",
-          "expr": "histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket{namespace=\"$namespace\"}[5m])) by (le, job))",
-          "legendFormat": "http_request_duration_seconds",
-          "range": true,
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "editorMode": "code",
-          "expr": "histogram_quantile(0.95, sum(rate(http_server_duration_seconds_bucket{namespace=\"$namespace\"}[5m])) by (le, job))",
-          "legendFormat": "http_server_duration_seconds",
-          "range": true,
-          "refId": "B"
-        }
-      ],
-      "title": "Latency приложения p95 (histogram)",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 10,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "smooth",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "reqps"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 24,
-        "x": 0,
-        "y": 26
-      },
-      "id": 7,
-      "options": {
-        "legend": {
-          "calcs": [
-            "mean",
-            "max",
-            "lastNotNull"
-          ],
-          "displayMode": "table",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
-        }
-      },
-      "pluginVersion": "10.0.0",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "editorMode": "code",
-          "expr": "sum(rate(http_requests_total{namespace=\"$namespace\",status=~\"5..\"}[5m]))",
-          "legendFormat": "5xx",
-          "range": true,
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "editorMode": "code",
-          "expr": "sum(rate(http_requests_total{namespace=\"$namespace\",status=~\"4..\"}[5m]))",
-          "legendFormat": "4xx",
-          "range": true,
-          "refId": "B"
-        }
-      ],
-      "title": "4xx / 5xx приложение (http_requests_total)",
-      "type": "timeseries"
-    },
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 34
       },
       "id": 102,
       "panels": [],
@@ -854,6 +501,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 10,
             "gradientMode": "none",
@@ -884,8 +532,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -901,7 +548,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 35
+        "y": 18
       },
       "id": 8,
       "options": {
@@ -916,11 +563,12 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "multi",
           "sort": "desc"
         }
       },
-      "pluginVersion": "10.0.0",
+      "pluginVersion": "11.6.1",
       "targets": [
         {
           "datasource": {
@@ -928,7 +576,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum by (pod) (kube_pod_container_status_restarts_total{namespace=\"$namespace\"})",
+          "expr": "sum by (pod) (increase(kube_pod_container_status_restarts_total{namespace=\"appraiser-help\"}[5m]))",
           "legendFormat": "{{pod}}",
           "range": true,
           "refId": "A"
@@ -954,6 +602,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 10,
             "gradientMode": "none",
@@ -984,8 +633,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1001,7 +649,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 35
+        "y": 18
       },
       "id": 9,
       "options": {
@@ -1016,11 +664,12 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "multi",
           "sort": "desc"
         }
       },
-      "pluginVersion": "10.0.0",
+      "pluginVersion": "11.6.1",
       "targets": [
         {
           "datasource": {
@@ -1028,7 +677,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum by (pod) (rate(container_cpu_cfs_throttled_seconds_total{namespace=\"$namespace\", container!=\"\"}[5m]))",
+          "expr": "sum by (pod) (rate(container_cpu_cfs_throttled_periods_total{namespace=\"$namespace\", container!=\"\"}[5m]))",
           "legendFormat": "{{pod}}",
           "range": true,
           "refId": "A"
@@ -1054,6 +703,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 10,
             "gradientMode": "none",
@@ -1084,8 +734,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1095,13 +744,38 @@
           },
           "unit": "short"
         },
-        "overrides": []
+        "overrides": [
+          {
+            "__systemRef": "hideSeriesFrom",
+            "matcher": {
+              "id": "byNames",
+              "options": {
+                "mode": "exclude",
+                "names": [
+                  "appraiser-help-web-68b8999754-jhtq2"
+                ],
+                "prefix": "All except:",
+                "readOnly": true
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": true
+                }
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 43
+        "y": 26
       },
       "id": 10,
       "options": {
@@ -1116,11 +790,12 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "multi",
           "sort": "desc"
         }
       },
-      "pluginVersion": "10.0.0",
+      "pluginVersion": "11.6.1",
       "targets": [
         {
           "datasource": {
@@ -1129,7 +804,7 @@
           },
           "editorMode": "code",
           "expr": "sum by (pod) (rate(container_cpu_usage_seconds_total{namespace=\"$namespace\", container!=\"POD\", container!=\"\"}[5m]))",
-          "legendFormat": "usage",
+          "legendFormat": "{{container}}",
           "range": true,
           "refId": "A"
         },
@@ -1140,12 +815,13 @@
           },
           "editorMode": "code",
           "expr": "sum by (pod) (kube_pod_container_resource_requests{namespace=\"$namespace\", resource=\"cpu\", container!=\"POD\", container!=\"\"})",
+          "hide": true,
           "legendFormat": "requests",
           "range": true,
           "refId": "B"
         }
       ],
-      "title": "CPU: usage vs requests (cores)",
+      "title": "CPU: usage (cores)",
       "type": "timeseries"
     },
     {
@@ -1165,6 +841,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 10,
             "gradientMode": "none",
@@ -1195,8 +872,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1212,7 +888,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 43
+        "y": 26
       },
       "id": 11,
       "options": {
@@ -1227,11 +903,12 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "multi",
           "sort": "desc"
         }
       },
-      "pluginVersion": "10.0.0",
+      "pluginVersion": "11.6.1",
       "targets": [
         {
           "datasource": {
@@ -1240,7 +917,7 @@
           },
           "editorMode": "code",
           "expr": "sum by (pod) (container_memory_working_set_bytes{namespace=\"$namespace\", container!=\"POD\", container!=\"\"})",
-          "legendFormat": "workingset",
+          "legendFormat": "{{instance}}",
           "range": true,
           "refId": "A"
         },
@@ -1251,12 +928,13 @@
           },
           "editorMode": "code",
           "expr": "sum by (pod) (kube_pod_container_resource_limits{namespace=\"$namespace\", resource=\"memory\", container!=\"POD\", container!=\"\"})",
-          "legendFormat": "limit",
+          "hide": true,
+          "legendFormat": "{{instance}} - limit",
           "range": true,
           "refId": "B"
         }
       ],
-      "title": "Memory: working set vs limit",
+      "title": "Memory: working set",
       "type": "timeseries"
     },
     {
@@ -1276,6 +954,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 10,
             "gradientMode": "none",
@@ -1306,8 +985,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1323,7 +1001,7 @@
         "h": 7,
         "w": 12,
         "x": 0,
-        "y": 51
+        "y": 34
       },
       "id": 12,
       "options": {
@@ -1338,11 +1016,12 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "multi",
           "sort": "desc"
         }
       },
-      "pluginVersion": "10.0.0",
+      "pluginVersion": "11.6.1",
       "targets": [
         {
           "datasource": {
@@ -1387,6 +1066,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 10,
             "gradientMode": "none",
@@ -1417,8 +1097,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1434,7 +1113,7 @@
         "h": 7,
         "w": 12,
         "x": 12,
-        "y": 51
+        "y": 34
       },
       "id": 13,
       "options": {
@@ -1449,11 +1128,12 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "multi",
           "sort": "desc"
         }
       },
-      "pluginVersion": "10.0.0",
+      "pluginVersion": "11.6.1",
       "targets": [
         {
           "datasource": {
@@ -1520,6 +1200,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 10,
             "gradientMode": "none",
@@ -1550,8 +1231,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1567,7 +1247,7 @@
         "h": 7,
         "w": 12,
         "x": 0,
-        "y": 58
+        "y": 41
       },
       "id": 14,
       "options": {
@@ -1582,11 +1262,12 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "multi",
           "sort": "desc"
         }
       },
-      "pluginVersion": "10.0.0",
+      "pluginVersion": "11.6.1",
       "targets": [
         {
           "datasource": {
@@ -1620,6 +1301,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 10,
             "gradientMode": "none",
@@ -1650,8 +1332,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1667,7 +1348,7 @@
         "h": 7,
         "w": 12,
         "x": 12,
-        "y": 58
+        "y": 41
       },
       "id": 15,
       "options": {
@@ -1682,11 +1363,12 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "multi",
           "sort": "desc"
         }
       },
-      "pluginVersion": "10.0.0",
+      "pluginVersion": "11.6.1",
       "targets": [
         {
           "datasource": {
@@ -1744,8 +1426,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               }
             ]
           }
@@ -1756,7 +1437,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 65
+        "y": 48
       },
       "id": 16,
       "options": {
@@ -1771,7 +1452,7 @@
         },
         "showHeader": true
       },
-      "pluginVersion": "10.0.0",
+      "pluginVersion": "11.6.1",
       "targets": [
         {
           "datasource": {
@@ -1806,28 +1487,34 @@
       "type": "table"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
       },
       "gridPos": {
         "h": 5,
         "w": 24,
         "x": 0,
-        "y": 73
+        "y": 56
       },
       "id": 999,
       "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
         "content": "**SRE-дашборд Citadel (Helm).** Ingress: метрики `nginx_ingress_controller_*` (ingress-nginx). При другом ingress замените запросы. Приложение: типичные метрики Prometheus/OpenTelemetry. Кластер: kube-state-metrics + cAdvisor. SLI по доступности: правило `up` для ServiceMonitor (PrometheusRule в чарте).",
         "mode": "markdown"
       },
-      "pluginVersion": "10.0.0",
+      "pluginVersion": "11.6.1",
       "title": "Примечания",
       "type": "text"
     }
   ],
+  "preload": false,
   "refresh": "30s",
-  "schemaVersion": 39,
+  "schemaVersion": 41,
   "tags": [
     "citadel",
     "kubernetes",
@@ -1837,11 +1524,9 @@
     "list": [
       {
         "current": {
-          "selected": false,
           "text": "Prometheus",
-          "value": "Prometheus"
+          "value": "prometheus"
         },
-        "hide": 0,
         "includeAll": false,
         "label": "Datasource",
         "name": "datasource",
@@ -1854,19 +1539,18 @@
       {
         "allValue": ".*",
         "current": {
-          "selected": false,
-          "text": "",
-          "value": ""
+          "text": "appraiser-help",
+          "value": "appraiser-help"
         },
         "datasource": {
           "type": "prometheus",
           "uid": "${datasource}"
         },
         "definition": "label_values(kube_pod_info, namespace)",
-        "hide": 0,
         "includeAll": false,
         "label": "Namespace",
         "name": "namespace",
+        "options": [],
         "query": {
           "query": "label_values(kube_pod_info, namespace)",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
@@ -1878,25 +1562,31 @@
       },
       {
         "current": {
-          "selected": true,
-          "text": "ingress-nginx",
-          "value": "ingress-nginx"
+          "text": "appraiser-help.ru",
+          "value": "appraiser-help.ru"
         },
-        "hide": 0,
+        "definition": "label_values(kube_ingress_path{namespace=\"$namespace\"},host)",
         "label": "Ingress controller NS",
         "name": "ingress_controller_namespace",
-        "query": "ingress-nginx",
-        "skipUrlSync": false,
-        "type": "textbox"
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(kube_ingress_path{namespace=\"$namespace\"},host)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "type": "query"
       }
     ]
   },
   "time": {
-    "from": "now-1h",
+    "from": "now-15m",
     "to": "now"
   },
+  "timepicker": {},
   "timezone": "browser",
   "title": "Citadel — SRE dashboard",
   "uid": "citadel-sre-release",
-  "version": 1
+  "version": 3
 }

--- a/charts/citadel-monolith/templates/grafana-dashboard-configmap.yaml
+++ b/charts/citadel-monolith/templates/grafana-dashboard-configmap.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.common.grafana.dashboard.enabled }}
+{{- $dash := .Values.common.grafana.dashboard }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ default (printf "%s-sre-dashboard" (include "citadel-common.fullname" .)) $dash.name }}
+  labels:
+    {{- include "citadel-common.labels" . | nindent 4 }}
+    {{- with $dash.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with $dash.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+data:
+  citadel-sre.json: |
+{{ .Files.Get "files/grafana-dashboards/citadel-sre.json" | nindent 4 }}
+{{- end }}

--- a/charts/citadel-monolith/values.yaml
+++ b/charts/citadel-monolith/values.yaml
@@ -10,6 +10,20 @@ serviceAccount:
 
 common:
   grafana:
+    # Опционально: ConfigMap с Grafana dashboard (SRE) для sidecar kube-prometheus-stack
+    # Включите common.grafana.dashboard.enabled: true — в namespace релиза появится ConfigMap;
+    # sidecar Grafana (label grafana_dashboard) подхватит JSON. Требуется kube-prometheus-stack
+    # (или аналог) с Prometheus, kube-state-metrics и метриками ingress-nginx при использовании
+    # панелей nginx_ingress_controller_*.
+    dashboard:
+      enabled: false
+      # Имя ConfigMap (по умолчанию: <release>-sre-dashboard)
+      name: ""
+      # Метки для sidecar grafana-sc-dashboard (kube-prometheus-stack): grafana_dashboard: "1"
+      labels:
+        grafana_dashboard: "1"
+      annotations: {}
+
   image:
     repository: nginx
     pullPolicy: IfNotPresent

--- a/scripts/generate-citadel-sre-dashboard.py
+++ b/scripts/generate-citadel-sre-dashboard.py
@@ -1,0 +1,601 @@
+#!/usr/bin/env python3
+"""Generate citadel SRE Grafana dashboard JSON (Grafana 9+)."""
+import json
+import os
+import sys
+
+ds_var = "${datasource}"
+ds_ref = {"type": "prometheus", "uid": ds_var}
+
+
+def timeseries(
+    id_,
+    title,
+    exprs,
+    unit="",
+    h=8,
+    w=12,
+    x=0,
+    y=0,
+):
+    targets = []
+    for i, (legend, expr) in enumerate(exprs):
+        ref = chr(65 + i) if i < 26 else str(i)
+        targets.append(
+            {
+                "datasource": ds_ref,
+                "editorMode": "code",
+                "expr": expr,
+                "legendFormat": legend,
+                "range": True,
+                "refId": ref,
+            }
+        )
+    return {
+        "datasource": ds_ref,
+        "fieldConfig": {
+            "defaults": {
+                "color": {"mode": "palette-classic"},
+                "custom": {
+                    "axisBorderShow": False,
+                    "axisCenteredZero": False,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "drawStyle": "line",
+                    "fillOpacity": 10,
+                    "gradientMode": "none",
+                    "hideFrom": {"legend": False, "tooltip": False, "viz": False},
+                    "insertNulls": False,
+                    "lineInterpolation": "smooth",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {"type": "linear"},
+                    "showPoints": "never",
+                    "spanNulls": False,
+                    "stacking": {"group": "A", "mode": "none"},
+                    "thresholdsStyle": {"mode": "off"},
+                },
+                "mappings": [],
+                "thresholds": {
+                    "mode": "absolute",
+                    "steps": [{"color": "green", "value": None}, {"color": "red", "value": 80}],
+                },
+                "unit": unit,
+            },
+            "overrides": [],
+        },
+        "gridPos": {"h": h, "w": w, "x": x, "y": y},
+        "id": id_,
+        "options": {
+            "legend": {
+                "calcs": ["mean", "max", "lastNotNull"],
+                "displayMode": "table",
+                "placement": "bottom",
+                "showLegend": True,
+            },
+            "tooltip": {"mode": "multi", "sort": "desc"},
+        },
+        "pluginVersion": "10.0.0",
+        "targets": targets,
+        "title": title,
+        "type": "timeseries",
+    }
+
+
+def row(id_, title, y):
+    return {
+        "collapsed": False,
+        "gridPos": {"h": 1, "w": 24, "x": 0, "y": y},
+        "id": id_,
+        "panels": [],
+        "title": title,
+        "type": "row",
+    }
+
+
+def main():
+    ing_ns = "$ingress_controller_namespace"
+    panels = []
+    y = 0
+    pid = 1
+
+    panels.append(row(100, "Ingress / API Gateway (nginx ingress controller)", y))
+    y += 1
+
+    panels.append(
+        timeseries(
+            pid,
+            "RPS по host (ingress)",
+            [
+                (
+                    "{{host}}",
+                    f'sum by (host) (rate(nginx_ingress_controller_requests{{namespace=~"{ing_ns}"}}[5m]))',
+                ),
+            ],
+            unit="reqps",
+            y=y,
+            x=0,
+        )
+    )
+    pid += 1
+    panels.append(
+        timeseries(
+            pid,
+            "RPS по ingress и по service (upstream)",
+            [
+                (
+                    "{{ingress}}",
+                    f'sum by (ingress) (rate(nginx_ingress_controller_requests{{namespace=~"{ing_ns}"}}[5m]))',
+                ),
+                (
+                    "{{service}}",
+                    f'sum by (service) (rate(nginx_ingress_controller_requests{{namespace=~"{ing_ns}"}}[5m]))',
+                ),
+            ],
+            unit="reqps",
+            y=y,
+            x=12,
+        )
+    )
+    pid += 1
+    y += 8
+
+    panels.append(
+        timeseries(
+            pid,
+            "Latency ingress — p50 / p95 / p99",
+            [
+                (
+                    "p50",
+                    f'histogram_quantile(0.50, sum(rate(nginx_ingress_controller_request_duration_seconds_bucket{{namespace=~"{ing_ns}"}}[5m])) by (le))',
+                ),
+                (
+                    "p95",
+                    f'histogram_quantile(0.95, sum(rate(nginx_ingress_controller_request_duration_seconds_bucket{{namespace=~"{ing_ns}"}}[5m])) by (le))',
+                ),
+                (
+                    "p99",
+                    f'histogram_quantile(0.99, sum(rate(nginx_ingress_controller_request_duration_seconds_bucket{{namespace=~"{ing_ns}"}}[5m])) by (le))',
+                ),
+            ],
+            unit="s",
+            y=y,
+            x=0,
+        )
+    )
+    pid += 1
+    panels.append(
+        timeseries(
+            pid,
+            "HTTP 4xx / 5xx (ingress)",
+            [
+                (
+                    "4xx",
+                    f'sum(rate(nginx_ingress_controller_requests{{namespace=~"{ing_ns}",status=~"4.."}}[5m]))',
+                ),
+                (
+                    "5xx",
+                    f'sum(rate(nginx_ingress_controller_requests{{namespace=~"{ing_ns}",status=~"5.."}}[5m]))',
+                ),
+            ],
+            unit="reqps",
+            y=y,
+            x=12,
+        )
+    )
+    pid += 1
+    y += 8
+
+    panels.append(row(101, "Приложение (namespace релиза)", y))
+    y += 1
+
+    panels.append(
+        timeseries(
+            pid,
+            "RPS по job (http_requests_total / http_server)",
+            [
+                (
+                    "http_requests_total",
+                    'sum by (job) (rate(http_requests_total{namespace="$namespace"}[5m]))',
+                ),
+                (
+                    "http_server_requests_total",
+                    'sum by (job) (rate(http_server_requests_total{namespace="$namespace"}[5m]))',
+                ),
+            ],
+            unit="reqps",
+            y=y,
+            x=0,
+        )
+    )
+    pid += 1
+    panels.append(
+        timeseries(
+            pid,
+            "Latency приложения p95 (histogram)",
+            [
+                (
+                    "http_request_duration_seconds",
+                    'histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket{namespace="$namespace"}[5m])) by (le, job))',
+                ),
+                (
+                    "http_server_duration_seconds",
+                    'histogram_quantile(0.95, sum(rate(http_server_duration_seconds_bucket{namespace="$namespace"}[5m])) by (le, job))',
+                ),
+            ],
+            unit="s",
+            y=y,
+            x=12,
+        )
+    )
+    pid += 1
+    y += 8
+
+    panels.append(
+        timeseries(
+            pid,
+            "4xx / 5xx приложение (http_requests_total)",
+            [
+                (
+                    "5xx",
+                    'sum(rate(http_requests_total{namespace="$namespace",status=~"5.."}[5m]))',
+                ),
+                (
+                    "4xx",
+                    'sum(rate(http_requests_total{namespace="$namespace",status=~"4.."}[5m]))',
+                ),
+            ],
+            unit="reqps",
+            w=24,
+            y=y,
+            x=0,
+        )
+    )
+    pid += 1
+    y += 8
+
+    panels.append(row(102, "Kubernetes: поды, ресурсы, джобы", y))
+    y += 1
+
+    panels.append(
+        timeseries(
+            pid,
+            "Рестарты контейнеров по pod",
+            [
+                (
+                    "{{pod}}",
+                    'sum by (pod) (kube_pod_container_status_restarts_total{namespace="$namespace"})',
+                ),
+            ],
+            unit="short",
+            y=y,
+            x=0,
+        )
+    )
+    pid += 1
+    panels.append(
+        timeseries(
+            pid,
+            "CPU throttling (container_cpu_cfs_throttled)",
+            [
+                (
+                    "{{pod}}",
+                    'sum by (pod) (rate(container_cpu_cfs_throttled_seconds_total{namespace="$namespace", container!=""}[5m]))',
+                ),
+            ],
+            unit="s/s",
+            y=y,
+            x=12,
+        )
+    )
+    pid += 1
+    y += 8
+
+    panels.append(
+        timeseries(
+            pid,
+            "CPU: usage vs requests (cores)",
+            [
+                (
+                    "usage",
+                    'sum by (pod) (rate(container_cpu_usage_seconds_total{namespace="$namespace", container!="POD", container!=""}[5m]))',
+                ),
+                (
+                    "requests",
+                    'sum by (pod) (kube_pod_container_resource_requests{namespace="$namespace", resource="cpu", container!="POD", container!=""})',
+                ),
+            ],
+            unit="short",
+            y=y,
+            x=0,
+        )
+    )
+    pid += 1
+    panels.append(
+        timeseries(
+            pid,
+            "Memory: working set vs limit",
+            [
+                (
+                    "workingset",
+                    'sum by (pod) (container_memory_working_set_bytes{namespace="$namespace", container!="POD", container!=""})',
+                ),
+                (
+                    "limit",
+                    'sum by (pod) (kube_pod_container_resource_limits{namespace="$namespace", resource="memory", container!="POD", container!=""})',
+                ),
+            ],
+            unit="bytes",
+            y=y,
+            x=12,
+        )
+    )
+    pid += 1
+    y += 8
+
+    panels.append(
+        timeseries(
+            pid,
+            "Доля requests от limits (CPU и memory, сумма по namespace)",
+            [
+                (
+                    "cpu",
+                    'clamp_max(sum(kube_pod_container_resource_requests{namespace="$namespace",resource="cpu"}) / sum(kube_pod_container_resource_limits{namespace="$namespace",resource="cpu"}), 1)',
+                ),
+                (
+                    "memory",
+                    'clamp_max(sum(kube_pod_container_resource_requests{namespace="$namespace",resource="memory"}) / sum(kube_pod_container_resource_limits{namespace="$namespace",resource="memory"}), 1)',
+                ),
+            ],
+            unit="percentunit",
+            h=7,
+            w=12,
+            y=y,
+            x=0,
+        )
+    )
+    pid += 1
+    panels.append(
+        timeseries(
+            pid,
+            "Фазы подов (Pod phase)",
+            [
+                (
+                    "Pending",
+                    'sum(kube_pod_status_phase{namespace="$namespace",phase="Pending"})',
+                ),
+                (
+                    "Running",
+                    'sum(kube_pod_status_phase{namespace="$namespace",phase="Running"})',
+                ),
+                (
+                    "Failed",
+                    'sum(kube_pod_status_phase{namespace="$namespace",phase="Failed"})',
+                ),
+                (
+                    "Succeeded",
+                    'sum(kube_pod_status_phase{namespace="$namespace",phase="Succeeded"})',
+                ),
+            ],
+            unit="short",
+            h=7,
+            w=12,
+            y=y,
+            x=12,
+        )
+    )
+    pid += 1
+    y += 7
+
+    panels.append(
+        timeseries(
+            pid,
+            "Ready condition (не готовы)",
+            [
+                (
+                    "NotReady count",
+                    'sum(kube_pod_status_condition{namespace="$namespace",condition="Ready",status="false"})',
+                ),
+            ],
+            unit="short",
+            h=7,
+            w=12,
+            y=y,
+            x=0,
+        )
+    )
+    pid += 1
+    panels.append(
+        timeseries(
+            pid,
+            "Jobs: failed / active / succeeded",
+            [
+                ("failed", 'sum(kube_job_status_failed{namespace="$namespace"})'),
+                ("active", 'sum(kube_job_status_active{namespace="$namespace"})'),
+                (
+                    "succeeded",
+                    'sum(kube_job_status_succeeded{namespace="$namespace"})',
+                ),
+            ],
+            unit="short",
+            h=7,
+            w=12,
+            y=y,
+            x=12,
+        )
+    )
+    pid += 1
+    y += 7
+
+    panels.append(
+        {
+            "datasource": ds_ref,
+            "fieldConfig": {
+                "defaults": {
+                    "custom": {
+                        "align": "auto",
+                        "cellOptions": {"type": "auto"},
+                        "inspect": False,
+                    },
+                    "mappings": [],
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [{"color": "green", "value": None}],
+                    },
+                },
+                "overrides": [],
+            },
+            "gridPos": {"h": 8, "w": 24, "x": 0, "y": y},
+            "id": pid,
+            "options": {
+                "cellHeight": "sm",
+                "footer": {
+                    "countRows": False,
+                    "fields": "",
+                    "reducer": ["sum"],
+                    "show": False,
+                },
+                "showHeader": True,
+            },
+            "pluginVersion": "10.0.0",
+            "targets": [
+                {
+                    "datasource": ds_ref,
+                    "editorMode": "code",
+                    "exemplar": False,
+                    "expr": 'kube_cronjob_info{namespace="$namespace"}',
+                    "format": "table",
+                    "instant": True,
+                    "legendFormat": "__auto",
+                    "refId": "A",
+                }
+            ],
+            "title": "CronJobs (kube_cronjob_info)",
+            "transformations": [
+                {
+                    "id": "organize",
+                    "options": {
+                        "excludeByName": {"Time": True, "Value": True},
+                        "indexByName": {},
+                        "renameByName": {"cronjob": "CronJob"},
+                    },
+                }
+            ],
+            "type": "table",
+        }
+    )
+    pid += 1
+    y += 8
+
+    panels.append(
+        {
+            "datasource": ds_ref,
+            "gridPos": {"h": 5, "w": 24, "x": 0, "y": y},
+            "id": 999,
+            "options": {
+                "content": (
+                    "**SRE-дашборд Citadel (Helm).** Ingress: метрики `nginx_ingress_controller_*` "
+                    "(ingress-nginx). При другом ingress замените запросы. Приложение: типичные метрики "
+                    "Prometheus/OpenTelemetry. Кластер: kube-state-metrics + cAdvisor. SLI по доступности: "
+                    "правило `up` для ServiceMonitor (PrometheusRule в чарте)."
+                ),
+                "mode": "markdown",
+            },
+            "pluginVersion": "10.0.0",
+            "title": "Примечания",
+            "type": "text",
+        }
+    )
+
+    dashboard = {
+        "annotations": {
+            "list": [
+                {
+                    "builtIn": 1,
+                    "datasource": {"type": "grafana", "uid": "-- Grafana --"},
+                    "enable": True,
+                    "hide": True,
+                    "iconColor": "rgba(0, 211, 255, 1)",
+                    "name": "Annotations & Alerts",
+                    "type": "dashboard",
+                }
+            ]
+        },
+        "editable": True,
+        "fiscalYearStartMonth": 0,
+        "graphTooltip": 1,
+        "links": [],
+        "liveNow": False,
+        "panels": panels,
+        "refresh": "30s",
+        "schemaVersion": 39,
+        "tags": ["citadel", "kubernetes", "sre"],
+        "templating": {
+            "list": [
+                {
+                    "current": {"selected": False, "text": "Prometheus", "value": "Prometheus"},
+                    "hide": 0,
+                    "includeAll": False,
+                    "label": "Datasource",
+                    "name": "datasource",
+                    "options": [],
+                    "query": "prometheus",
+                    "refresh": 1,
+                    "regex": "",
+                    "type": "datasource",
+                },
+                {
+                    "allValue": ".*",
+                    "current": {"selected": False, "text": "", "value": ""},
+                    "datasource": ds_ref,
+                    "definition": "label_values(kube_pod_info, namespace)",
+                    "hide": 0,
+                    "includeAll": False,
+                    "label": "Namespace",
+                    "name": "namespace",
+                    "query": {
+                        "query": "label_values(kube_pod_info, namespace)",
+                        "refId": "PrometheusVariableQueryEditor-VariableQuery",
+                    },
+                    "refresh": 1,
+                    "regex": "",
+                    "sort": 1,
+                    "type": "query",
+                },
+                {
+                    "current": {
+                        "selected": True,
+                        "text": "ingress-nginx",
+                        "value": "ingress-nginx",
+                    },
+                    "hide": 0,
+                    "label": "Ingress controller NS",
+                    "name": "ingress_controller_namespace",
+                    "query": "ingress-nginx",
+                    "skipUrlSync": False,
+                    "type": "textbox",
+                },
+            ]
+        },
+        "time": {"from": "now-1h", "to": "now"},
+        "timezone": "browser",
+        "title": "Citadel — SRE dashboard",
+        "uid": "citadel-sre-release",
+        "version": 1,
+    }
+
+    root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    out = os.path.join(
+        root,
+        "charts/citadel-monolith/files/grafana-dashboards/citadel-sre.json",
+    )
+    os.makedirs(os.path.dirname(out), exist_ok=True)
+    with open(out, "w", encoding="utf-8") as f:
+        json.dump(dashboard, f, indent=2, ensure_ascii=False)
+    print(out, file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/helm-template-test.sh
+++ b/scripts/helm-template-test.sh
@@ -16,6 +16,12 @@ helm template test-citadel-mon charts/citadel-monolith \
   --show-only templates/prometheusrule.yaml \
   --show-only templates/service.yaml
 
+echo "== citadel-monolith: Grafana SRE dashboard ConfigMap =="
+helm template test-citadel-dash charts/citadel-monolith \
+  -f charts/citadel-monolith/ci/sre-dashboard-values.yaml \
+  --namespace app-test \
+  --show-only templates/grafana-dashboard-configmap.yaml
+
 echo "== static-proxy: gateway API values =="
 helm template test-static charts/static-proxy \
   -f charts/static-proxy/ci/gateway-api-values.yaml \

--- a/scripts/test_citadel_sre_dashboard.py
+++ b/scripts/test_citadel_sre_dashboard.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Smoke test: SRE dashboard JSON is valid and has expected structure."""
+import json
+import os
+import subprocess
+import sys
+import unittest
+
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+JSON_PATH = os.path.join(
+    ROOT,
+    "charts/citadel-monolith/files/grafana-dashboards/citadel-sre.json",
+)
+
+
+class TestCitadelSreDashboard(unittest.TestCase):
+    def test_json_file_exists_and_parses(self):
+        self.assertTrue(os.path.isfile(JSON_PATH), JSON_PATH)
+        with open(JSON_PATH, encoding="utf-8") as f:
+            data = json.load(f)
+        self.assertEqual(data.get("uid"), "citadel-sre-release")
+        self.assertIn("panels", data)
+        self.assertGreater(len(data["panels"]), 3)
+        names = {v.get("name") for v in data.get("templating", {}).get("list", [])}
+        self.assertIn("namespace", names)
+        self.assertIn("ingress_controller_namespace", names)
+
+    def test_helm_renders_configmap_with_dashboard(self):
+        proc = subprocess.run(
+            [
+                "helm",
+                "template",
+                "t",
+                os.path.join(ROOT, "charts/citadel-monolith"),
+                "-f",
+                os.path.join(
+                    ROOT,
+                    "charts/citadel-monolith/ci/sre-dashboard-values.yaml",
+                ),
+                "--namespace",
+                "app-test",
+                "--show-only",
+                "templates/grafana-dashboard-configmap.yaml",
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if proc.returncode != 0:
+            self.fail(proc.stderr or proc.stdout)
+        self.assertIn("kind: ConfigMap", proc.stdout)
+        self.assertIn("citadel-sre.json:", proc.stdout)
+        self.assertIn("citadel-sre-release", proc.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Изменения

- Добавлен **Grafana dashboard JSON** `citadel-sre.json`: RPS и latency по **nginx ingress** (host, ingress, upstream service), 4xx/5xx; RPS/latency/ошибки по типичным метрикам приложения (`http_requests_total`, histogram); по Kubernetes — рестарты, CPU throttling, usage vs requests/limits, доля requests от limits, фазы подов, Ready, Jobs, таблица CronJobs (`kube_cronjob_info`).
- Опциональный **ConfigMap** через `common.grafana.dashboard.enabled` с метками для sidecar **kube-prometheus-stack** (`grafana_dashboard: "1"` по умолчанию).
- Скрипт **генерации** JSON из Python (`scripts/generate-citadel-sre-dashboard.py`), **smoke-тест** (`scripts/test_citadel_sre_dashboard.py`), обновлён `scripts/helm-template-test.sh`, CI values `ci/sre-dashboard-values.yaml`.
- Версия чарта **0.2.5**.

## Требования к кластеру

Prometheus + kube-state-metrics + cAdvisor; для панелей ingress — **ingress-nginx** и метрики `nginx_ingress_controller_*` (namespace контроллера задаётся переменной на дашборде). При другом ingress/Gateway — запросы можно заменить в Grafana или перегенерировать скриптом.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dfcbf015-73b0-439c-8984-1f33bb42914d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dfcbf015-73b0-439c-8984-1f33bb42914d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

