### PR TITLE
feat(citadel-monolith): стратегия обновления для applications

### DIFF
--- a/charts/citadel-monolith/Chart.yaml
+++ b/charts/citadel-monolith/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: citadel
 description: A Helm chart for deploying monolithic applications in Kubernetes with enhanced security, monitoring, and configuration management
 type: application
-version: 0.2.5
+version: 0.2.6
 appVersion: "1.0.0"
 keywords:
   - kubernetes

--- a/charts/citadel-monolith/README.md
+++ b/charts/citadel-monolith/README.md
@@ -61,6 +61,11 @@ The chart supports deploying multiple applications. Each application can have:
 applications:
   - name: nginx
     replicaCount: 1
+    # recreate | rollingUpdate (omit for Kubernetes default RollingUpdate)
+    updateStrategy: rollingUpdate
+    # rollingUpdate:
+    #   maxUnavailable: 0
+    #   maxSurge: 1
     image:
       repository: nginx
       tag: "latest"

--- a/charts/citadel-monolith/ci/update-strategy-values.yaml
+++ b/charts/citadel-monolith/ci/update-strategy-values.yaml
@@ -1,0 +1,23 @@
+# CI: стратегии обновления Deployment (recreate / rollingUpdate)
+applications:
+  - name: recreate-app
+    replicaCount: 1
+    updateStrategy: recreate
+    image:
+      repository: nginx
+      tag: "1.29"
+    service:
+      type: ClusterIP
+      port: 80
+  - name: rolling-app
+    replicaCount: 2
+    updateStrategy: rollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+    image:
+      repository: nginx
+      tag: "1.29"
+    service:
+      type: ClusterIP
+      port: 80

--- a/charts/citadel-monolith/templates/deployment.yaml
+++ b/charts/citadel-monolith/templates/deployment.yaml
@@ -18,6 +18,21 @@ spec:
   {{- if not (and .autoscaling .autoscaling.enabled) }}
   replicas: {{ .replicaCount }}
   {{- end }}
+  {{- if .updateStrategy }}
+  {{- $strategyType := .updateStrategy | lower }}
+  strategy:
+    {{- if eq $strategyType "recreate" }}
+    type: Recreate
+    {{- else if eq $strategyType "rollingupdate" }}
+    type: RollingUpdate
+    {{- with .rollingUpdate }}
+    rollingUpdate:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- else }}
+    {{- fail (printf "application %q: updateStrategy must be recreate or rollingUpdate, got %q" .name .updateStrategy) }}
+    {{- end }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "citadel-common.selectorLabels" $ | nindent 6 }}

--- a/charts/citadel-monolith/values.yaml
+++ b/charts/citadel-monolith/values.yaml
@@ -129,6 +129,11 @@ jobs: []
 applications: []
   # - name: nginx
   #   replicaCount: 1
+  #   # recreate | rollingUpdate (по умолчанию — RollingUpdate в Kubernetes)
+  #   updateStrategy: rollingUpdate
+  #   # rollingUpdate:
+  #   #   maxUnavailable: 0
+  #   #   maxSurge: 1
   #   env: []
   #   image:
   #     repository: nginx

--- a/scripts/helm-template-test.sh
+++ b/scripts/helm-template-test.sh
@@ -40,4 +40,11 @@ helm template test-static-hpa charts/static-proxy \
   --show-only templates/hpa.yaml \
   --show-only templates/deployment.yaml
 
+echo "== citadel-monolith: update strategy (recreate / rollingUpdate) =="
+helm template test-citadel-strategy charts/citadel-monolith \
+  -f charts/citadel-monolith/ci/update-strategy-values.yaml \
+  --namespace app-test \
+  --show-only templates/deployment.yaml
+python3 scripts/test_citadel_update_strategy.py
+
 echo "OK: Gateway API and HPA templates render successfully."

--- a/scripts/test_citadel_update_strategy.py
+++ b/scripts/test_citadel_update_strategy.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Smoke test: application updateStrategy renders correct Deployment strategy."""
+import os
+import re
+import subprocess
+import unittest
+
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+CHART = os.path.join(ROOT, "charts/citadel-monolith")
+VALUES = os.path.join(CHART, "ci/update-strategy-values.yaml")
+
+
+def render_deployments() -> str:
+    proc = subprocess.run(
+        [
+            "helm",
+            "template",
+            "t",
+            CHART,
+            "-f",
+            VALUES,
+            "--namespace",
+            "app-test",
+            "--show-only",
+            "templates/deployment.yaml",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(proc.stderr or proc.stdout)
+    return proc.stdout
+
+
+def deployment_block(name: str, rendered: str) -> str:
+    docs = re.split(r"\n---\n", rendered)
+    for doc in docs:
+        if re.search(rf"name: .*-{re.escape(name)}\s*$", doc, re.MULTILINE):
+            return doc
+    raise AssertionError(f"deployment for {name!r} not found")
+
+
+class TestCitadelUpdateStrategy(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.rendered = render_deployments()
+
+    def test_recreate_strategy(self):
+        block = deployment_block("recreate-app", self.rendered)
+        self.assertIn("type: Recreate", block)
+        self.assertNotIn("rollingUpdate:", block)
+
+    def test_rolling_update_strategy(self):
+        block = deployment_block("rolling-app", self.rendered)
+        self.assertIn("type: RollingUpdate", block)
+        self.assertIn("maxUnavailable: 0", block)
+        self.assertIn("maxSurge: 1", block)
+
+    def test_default_omits_strategy(self):
+        proc = subprocess.run(
+            [
+                "helm",
+                "template",
+                "t",
+                CHART,
+                "-f",
+                os.path.join(CHART, "ci/hpa-values.yaml"),
+                "--namespace",
+                "app-test",
+                "--show-only",
+                "templates/deployment.yaml",
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(proc.returncode, 0, proc.stderr or proc.stdout)
+        self.assertNotIn("strategy:", proc.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Описание

Добавлена возможность задавать стратегию обновления Deployment для каждого приложения в `applications`.

## Изменения

- Новое поле `updateStrategy` со значениями `recreate` или `rollingUpdate`
- Опциональный блок `rollingUpdate` для настройки `maxUnavailable` / `maxSurge`
- Если поле не указано, поведение не меняется (используется дефолт Kubernetes — `RollingUpdate`)
- CI-фикстура и unit-тесты для проверки рендеринга шаблонов
- Версия чарта: `0.2.6`

## Пример

```yaml
applications:
  - name: web
    replicaCount: 1
    updateStrategy: recreate
  - name: api
    replicaCount: 2
    updateStrategy: rollingUpdate
    rollingUpdate:
      maxUnavailable: 0
      maxSurge: 1
```

## Тестирование

- `./scripts/helm-template-test.sh`
- `python3 scripts/test_citadel_update_strategy.py`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a7eb2b61-e23d-4037-b0b5-0c0b8e23d850"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a7eb2b61-e23d-4037-b0b5-0c0b8e23d850"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

